### PR TITLE
Add pinouts/wire color codes DJH

### DIFF
--- a/wiring_guides/turntable.md
+++ b/wiring_guides/turntable.md
@@ -35,4 +35,12 @@ If you are new to this, read the [following guide](https://santroller.tangentmc.
 ## Wiring Steps (Peripheral, Pi Pico only)
 If you would like your frets to contain LEDs, or want your frets to poll at a different rate to the rest of the turntable, you can use the [Peripheral feature](https://santroller.tangentmc.net/wiring_guides/peripheral.html).
 
+Note: If using peripheral mode, here are the wire color codes:
+
+YELLOW: DATA (D)
+BLUE: GND (G)
+GREEN: CLK (C)
+RED: 3V3 (V)
+WHITE: SENSE PIN (ID)
+
 Now that you have wired your turntable, go [configure it](https://santroller.tangentmc.net/tool/using.html).

--- a/wiring_guides/turntable.md
+++ b/wiring_guides/turntable.md
@@ -35,7 +35,7 @@ If you are new to this, read the [following guide](https://santroller.tangentmc.
 ## Wiring Steps (Peripheral, Pi Pico only)
 If you would like your frets to contain LEDs, or want your frets to poll at a different rate to the rest of the turntable, you can use the [Peripheral feature](https://santroller.tangentmc.net/wiring_guides/peripheral.html).
 
-Note: If using peripheral mode, here are the wire color codes:
+Note: If using peripheral mode, here are the wire color codes and pinouts:
 
 * YELLOW: DATA (D)
 * BLUE: GND (G)

--- a/wiring_guides/turntable.md
+++ b/wiring_guides/turntable.md
@@ -37,10 +37,10 @@ If you would like your frets to contain LEDs, or want your frets to poll at a di
 
 Note: If using peripheral mode, here are the wire color codes:
 
-YELLOW: DATA (D)
-BLUE: GND (G)
-GREEN: CLK (C)
-RED: 3V3 (V)
-WHITE: SENSE PIN (ID)
+* YELLOW: DATA (D)
+* BLUE: GND (G)
+* GREEN: CLK (C)
+* RED: 3V3 (V)
+* WHITE: SENSE PIN (ID)
 
 Now that you have wired your turntable, go [configure it](https://santroller.tangentmc.net/tool/using.html).


### PR DESCRIPTION
Adds pinouts/wire color codes for wiring a DJH table in peripheral mode