### PR TITLE
add support for ps2 popn controllers

### DIFF
--- a/src/shared/main/ps2.cpp
+++ b/src/shared/main/ps2.cpp
@@ -208,7 +208,11 @@ uint8_t *tickPS2() {
             } else {
                 ps2ControllerType = PSX_DUALSHOCK_2_CONTROLLER;
             }
-        } else if (isDualShockReply(in)) {
+        } 
+        else if (bit_check(buttonWord, PSB_PAD_LEFT, PSB_PAD_DOWN, PSB_PAD_RIGHT)) {
+                ps2ControllerType = PSX_POPN_CONTROLLER;
+        }
+        else if (isDualShockReply(in)) {
             uint16_t buttonWord = ~(((uint16_t)in[4] << 8) | in[3]);
             if (bit_check(buttonWord, PSB_PAD_LEFT)) {
                 ps2ControllerType = PSX_GUITAR_HERO_CONTROLLER;


### PR DESCRIPTION
not sure is this is proper but it does hold left down and right always to make it identify as a popn music controller

also not sure if this is needed, i only did this because one of the buttons that the controller uses is the up button and some ps2 controller adapters just dont like this lol