### PR TITLE
Fix WS2812 LED debounce after changes in 3d7da5c

### DIFF
--- a/src/shared/main/shared_main.cpp
+++ b/src/shared/main/shared_main.cpp
@@ -2535,7 +2535,7 @@ void tick(void) {
                 debounce[i]--;
             }
         }
-#if LED_COUNT || HAS_LED_OUTPUT
+#if REQUIRE_LED_DEBOUNCE
         for (int i = 0; i < LED_DEBOUNCE_COUNT; i++) {
             if (ledDebounce[i]) {
                 ledDebounce[i]--;


### PR DESCRIPTION
This fixes issue #198 in line with previous commit's debounce macro changes

Thanks for this awesome software!