### PR TITLE
Bluetooth LE Player ID LED assignment functionality for PS3, XBox 360/Windows

### DIFF
--- a/include/hid.h
+++ b/include/hid.h
@@ -84,6 +84,7 @@ extern const uint8_t fnf_descriptor[53];
 extern long last_strobe;
 extern uint8_t stage_kit_millis[5];
 extern uint8_t strobe_delay;
+extern uint8_t current_player;
 #if DEVICE_TYPE_IS_INSTRUMENT
 #if HID_BUTTON_PADDING
 extern const uint8_t pc_descriptor[90 + 2*HID_BUTTON_COUNT + 2*HID_AXIS_COUNT];
@@ -95,6 +96,7 @@ extern const uint8_t pc_descriptor[158];
 #endif
 void handle_auth_led(void);
 void handle_player_leds(uint8_t player);
+void reset_player_leds(void);
 void handle_rumble(uint8_t rumble_left, uint8_t rumble_right);
 void handle_keyboard_leds(uint8_t leds);
 void tick_leds(void);
@@ -103,4 +105,5 @@ uint8_t hid_get_report(uint8_t *data, uint8_t reqLen, uint8_t reportType, uint8_
 uint16_t handle_serial_command(uint8_t request, uint16_t wValue, uint8_t* response_buffer, bool* success);
 #if BLUETOOTH_RX
 void bt_set_report(const uint8_t *data, uint8_t len, uint8_t reportType, uint8_t report_id);
+void send_player_leds_bt(void);
 #endif

--- a/src/pico/bt.cpp
+++ b/src/pico/bt.cpp
@@ -184,6 +184,7 @@ static void packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packe
     switch (hci_event_packet_get_type(packet)) {
         case HCI_EVENT_DISCONNECTION_COMPLETE:
             con_handle = HCI_CON_HANDLE_INVALID;
+            reset_player_leds();
             printf("Disconnected\r\n");
             break;
         case SM_EVENT_JUST_WORKS_REQUEST:

--- a/src/pico/bt_rx.cpp
+++ b/src/pico/bt_rx.cpp
@@ -65,6 +65,9 @@ static uint8_t hid_descriptor_storage[500];
 static uint8_t send_report_buf[64];
 static uint8_t send_report_len = 0;
 
+// Set up simulated GATTSERVICE_SUBEVENT_HID_SERVICE_REPORTS_NOTIFICATION 
+static bool reports_notif_pending = false;
+
 // used to implement connection timeout and reconnect timer
 static btstack_timer_source_t connection_timer;
 static btstack_timer_source_t reconnect_timer;
@@ -113,9 +116,10 @@ int get_bt_address(uint8_t *addr)
 
 void bt_set_report(const uint8_t *data, uint8_t len, uint8_t reportType, uint8_t report_id)
 {
-    hids_host_send_write_report(hids_cid, 1, HID_REPORT_TYPE_OUTPUT, send_report_buf, send_report_len);
     memcpy(send_report_buf, data, len);
     send_report_len = len;
+    // Reorder to after memcopy so that reports get properly flushed, needed for 360.
+    hids_host_send_write_report(hids_cid, 1, HID_REPORT_TYPE_OUTPUT, send_report_buf, send_report_len);
 }
 
 bool check_bluetooth_ready()
@@ -337,10 +341,15 @@ static void handle_gatt_client_event(uint8_t packet_type, uint16_t channel, uint
                 type.console_type = PS3;
             }
         }
+        reports_notif_pending = true;
         break;
     }
     case GATTSERVICE_SUBEVENT_HID_REPORT:
     {
+        // On first report after connection, send Player IDs
+        if (reports_notif_pending && current_player != 0xFF) {
+            reports_notif_pending = false;
+        }
         if (type.console_type == GENERIC)
         {
             fill_generic_report(info, gattservice_subevent_hid_report_get_report(packet), &bt_data);

--- a/src/pico/bt_rx.cpp
+++ b/src/pico/bt_rx.cpp
@@ -349,6 +349,7 @@ static void handle_gatt_client_event(uint8_t packet_type, uint16_t channel, uint
         // On first report after connection, send Player IDs
         if (reports_notif_pending && current_player != 0xFF) {
             reports_notif_pending = false;
+            send_player_leds_bt();
         }
         if (type.console_type == GENERIC)
         {

--- a/src/shared/hid/hid.cpp
+++ b/src/shared/hid/hid.cpp
@@ -309,6 +309,11 @@ void handle_player_leds(uint8_t player)
     }
 #endif
 }
+void reset_player_leds(void) {
+    uint8_t player = 0;
+    current_player = 0xFF;
+    HANDLE_PLAYER_LED;
+}
 // PS3 controllers and other controllers use different LED bitmasks
 #if DEVICE_TYPE == GAMEPAD
 void handle_player_leds_ps3(uint8_t player_mask)
@@ -387,6 +392,16 @@ void handle_lightbar_leds(uint8_t red, uint8_t green, uint8_t blue)
         }
     }
 }
+#if BLUETOOTH_RX
+void send_player_leds_bt(void)
+{
+    if (current_player != 0xFF)
+    {
+        uint8_t player_leds_report[8] = {PS3_REPORT_ID, PS3_RUMBLE_ID, 0, (uint8_t)(1 << (current_player - 1)), 0, 0, 0, 0};
+        bt_set_report(player_leds_report, sizeof(player_leds_report), 1, 1);
+    }
+}
+#endif
 
 void handle_rumble(uint8_t rumble_left, uint8_t rumble_right)
 {
@@ -713,9 +728,7 @@ void hid_set_report(const uint8_t *data, uint8_t len, uint8_t reportType, uint8_
             if (player)
             {
                 handle_player_leds(player);
-                data_hid[1] = PS3_RUMBLE_ID;
-                data_hid[3] = 1 << player;
-                bt_set_report(data_hid, 8, reportType, report_id);
+                send_player_leds_bt();
             }
         }
         else if (id == XBOX_RUMBLE_ID)
@@ -746,6 +759,10 @@ void hid_set_report(const uint8_t *data, uint8_t len, uint8_t reportType, uint8_
             // Pass combined reports directly over bt
         }
         else if (id == SANTROLLER_LED_EXPANDED_ID || (id == PS3_REPORT_ID && data[1] == SANTROLLER_LED_EXPANDED_ID))
+        {
+            bt_set_report(data, len, reportType, report_id);
+        }
+        else if (id == PS3_REPORT_ID && data[1] == 0x08) // PS3s apparently send an 8 byte Player ID report, and that length is in data[1]
         {
             bt_set_report(data, len, reportType, report_id);
         }

--- a/src/shared/main/accel.cpp
+++ b/src/shared/main/accel.cpp
@@ -107,6 +107,7 @@ void init_accel()
 }
 void tick_accel()
 {
+    int16_t raw[3];
     if (!accel_found)
     {
         for (int i = 0; i < 3; i++)
@@ -116,7 +117,6 @@ void tick_accel()
         init_accel();
         return;
     }
-    int16_t raw[3];
     if (type == LIS3DH)
     {
         accel_found = twi_readFromPointer(ACCEL_TWI_PORT, lis3dh_address, LIS3DH_REG_OUT, 6, (uint8_t *)raw);


### PR DESCRIPTION
Implemented changes to support forwarding PS3 Player ID data over Bluetooth LE. There's a magic 0x08 in the comparison, and my best understanding is that this is an explicit report length byte which corresponds to the Player ID report.

Changes have been made to the Bluetooth event handler to perform an action on the first writable report to submit Player ID data over Bluetooth. There's supposed to be an 0x1C event for this sort of thing, but the upstream dependency does not appear to fire it, thus the roundabout way of tracking and firing an event.

That particular event has been wired into functionality to send the Player ID on successful BT connection, since the XBox 360 and Windows controller functionality only appears to send player IDs once, and that's before the BT controller is able to connect.

There's also been a small re-ordering of the hids_host_send_write_report function to after a memcopy rather than before, as without it the controller doesn't seem to receive the report from the 360/Windows flow.

Finally, there was a compile time error on one of the two configs tested during this change on the accel file, so a hoisting of the structure was done to enable compilation for testing.